### PR TITLE
Remove Coveralls integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,15 +45,5 @@ jobs:
         run: npm ci
       - name: Build project
         run: npm run build
-      - name: Test and collect coverage info
+      - name: Run tests
         run: npm run test
-      - name: Coveralls Parallel
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true

--- a/readme.md
+++ b/readme.md
@@ -2,12 +2,11 @@
 
 [![NPM Version](https://img.shields.io/npm/v/typed-event-dispatcher.svg?style=flat)](https://www.npmjs.org/package/typed-event-dispatcher)
 [![Types](https://img.shields.io/npm/types/typed-event-dispatcher)](https://www.jsdocs.io/package/typed-event-dispatcher#package-index)
-[![Coverage Status](https://coveralls.io/repos/github/felladrin/typed-event-dispatcher/badge.svg?branch=master)](https://coveralls.io/github/felladrin/typed-event-dispatcher?branch=master)
 [![License](https://img.shields.io/github/license/felladrin/typed-event-dispatcher)](http://victor.mit-license.org/)
 
 Strongly-typed events that can be publicly listened but internally-only dispatched.
 
-A [lightweight](https://bundlephobia.com/result?p=typed-event-dispatcher), [fully-tested](https://coveralls.io/github/felladrin/typed-event-dispatcher) and [dependency-free](https://www.npmjs.com/package/typed-event-dispatcher) lib made for Typescript ([see live example](https://repl.it/@victornogueira/typed-event-dispatcher-typescript-example)) and JavaScript ([see live example](https://repl.it/@victornogueira/typed-event-dispatcher-javascript-example)) codebases.
+A [lightweight](https://bundlephobia.com/result?p=typed-event-dispatcher), [fully-tested](https://github.com/felladrin/typed-event-dispatcher/blob/master/test/typed-event-dispatcher.test.ts) and [dependency-free](https://www.npmjs.com/package/typed-event-dispatcher) lib made for Typescript ([see live example](https://repl.it/@victornogueira/typed-event-dispatcher-typescript-example)) and JavaScript ([see live example](https://repl.it/@victornogueira/typed-event-dispatcher-javascript-example)) codebases.
 
 This is intended to be used with Classes. If you prefer using only Functions, please check [create-pubsub](https://www.npmjs.com/package/create-pubsub).
 


### PR DESCRIPTION
Removes Coveralls from the repository. The CI step had started failing with a 500 `Build processing error` on every run, so the coverage upload no longer works.

This PR does three things:

- Drops the `Coveralls Parallel` and `Coveralls Finished` steps from the build workflow.
- Removes the coverage badge from the readme.
- Repoints the `fully-tested` readme link (it pointed to the dead Coveralls page) to the test file on GitHub.

Tests still run in CI, and `jest --collectCoverage` still prints the coverage summary in the job log; it just no longer gets uploaded anywhere.

## How to test

1. Check the `Build and Test` workflow on this PR: the `Run tests` step passes and there are no Coveralls steps.
2. Open the rendered readme and confirm the coverage badge is gone and the `fully-tested` link resolves.